### PR TITLE
Store OpenSeadragon Viewer instantiation object handle

### DIFF
--- a/app/assets/javascripts/openseadragon/rails.js
+++ b/app/assets/javascripts/openseadragon/rails.js
@@ -31,9 +31,9 @@
       $picture.css("display", "block");
       $picture.css("height", "500px");
 
-      OpenSeadragon(
+      $picture.data('osdViewer', OpenSeadragon(
         $.extend({ id: $picture.attr('id') }, collectionOptions, { tileSources: tilesources })
-      );
+      ));
     });
   };
 


### PR DESCRIPTION
`OpenSeadragon.Viewer` instantiation object handle needs to be stored for attaching handlers to events like `open`, `close` etc.

Use case: To update current page number in Spotlight's multi-image display, `OpenSeadragon.Viewer` handle is needed for providing a callback to `page` event.

Reference: https://github.com/openseadragon/openseadragon/issues/317#issuecomment-32063089
