### PR TITLE
Add 3rd parameter to addEventListener for backwards browser compat.

### DIFF
--- a/app/assets/javascripts/openseadragon/rails.js
+++ b/app/assets/javascripts/openseadragon/rails.js
@@ -38,5 +38,5 @@
   };
 
   window.onload = initOpenSeadragon;
-  document.addEventListener("page:load", initOpenSeadragon);
+  document.addEventListener("page:load", initOpenSeadragon, false);
 })(jQuery);


### PR DESCRIPTION
See notes in https://developer.mozilla.org/en-US/docs/Web/API/EventTarget.addEventListener#Syntax

Not sure if we should take this, or push it upstream or not, but it certainly causes failures in SearchWorks.