### PR TITLE
Ensure there is a new line before appending to config

### DIFF
--- a/lib/generators/openseadragon/install_generator.rb
+++ b/lib/generators/openseadragon/install_generator.rb
@@ -20,9 +20,7 @@ module Openseadragon
 
     def append_image_paths
       append_to_file 'config/initializers/assets.rb' do
-        <<~CONTENT
-          Rails.application.config.assets.paths << Rails.application.root + 'node_modules/openseadragon/build/openseadragon/images'
-        CONTENT
+        "\nRails.application.config.assets.paths << Rails.application.root + 'node_modules/openseadragon/build/openseadragon/images'\n"
       end
     end
 

--- a/lib/generators/openseadragon/install_generator.rb
+++ b/lib/generators/openseadragon/install_generator.rb
@@ -20,7 +20,7 @@ module Openseadragon
 
     def append_image_paths
       append_to_file 'config/initializers/assets.rb' do
-        "\nRails.application.config.assets.paths << Rails.application.root + 'node_modules/openseadragon/build/openseadragon/images'\n"
+        "\nRails.application.config.assets.paths << Rails.root.join('node_modules/openseadragon/build/openseadragon/images')\n"
       end
     end
 


### PR DESCRIPTION
Fixes:
```
bin/rails aborted!
SyntaxError: --> /home/runner/work/blacklight-gallery/blacklight-gallery/.internal_test_app/config/initializers/assets.rb
expected a newline or semicolon after the statement
>  4  Rails.application.config.assets.version = "1.0"
>  8  Rails.application.config.assets.paths << Rails.root.join("node_modules/bootstrap/dist/js")
>  9  Rails.application.config.assets.paths << Rails.root.join("node_modules/bootstrap-icons/font")
> 10  Rails.application.config.assets.paths << Rails.root.join("node_modules/bootstrap/dist/js")
> 11  Rails.application.config.assets.precompile << "bootstrap.min.js"Rails.application.config.assets.paths << Rails.application.root + 'node_modules/openseadragon/build/openseadragon/images'
/home/runner/work/blacklight-gallery/blacklight-gallery/.internal_test_app/config/initializers/assets.rb:11: syntax error, unexpected constant, expecting end-of-input (SyntaxError)
...pile << "bootstrap.min.js"Rails.application.config.assets.pa...
...                          ^~~~~
/home/runner/work/blacklight-gallery/blacklight-gallery/.internal_test_app/config/environment.rb:5:in `<top (required)>'
```