### PR TITLE
Add OSD images to assets precompile

### DIFF
--- a/lib/openseadragon/engine.rb
+++ b/lib/openseadragon/engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Openseadragon
   class Engine < ::Rails::Engine
     isolate_namespace Openseadragon
@@ -14,9 +16,22 @@ module Openseadragon
       end
     end
 
-    initializer "openseadragon.importmap", before: "importmap" do |app|
-      app.config.assets.paths << Engine.root.join("app/javascript")
-      app.config.importmap.paths << Engine.root.join("config/importmap.rb") if app.config.respond_to?(:importmap)
+    initializer 'openseadragon.assets.precompile' do |app|
+      app.config.assets.precompile += %w[
+        button_grouphover.png flip_pressed.png home_grouphover.png next_pressed.png rotateleft_grouphover.png
+        rotateright_pressed.png zoomout_grouphover.png button_hover.png flip_rest.png home_hover.png next_rest.png
+        rotateleft_hover.png rotateright_rest.png zoomout_hover.png button_pressed.png fullpage_grouphover.png
+        home_pressed.png previous_grouphover.png rotateleft_pressed.png zoomin_grouphover.png zoomout_pressed.png
+        button_rest.png fullpage_hover.png home_rest.png previous_hover.png rotateleft_rest.png zoomin_hover.png
+        zoomout_rest.png flip_grouphover.png fullpage_pressed.png next_grouphover.png previous_pressed.png
+        rotateright_grouphover.png zoomin_pressed.png flip_hover.png fullpage_rest.png next_hover.png previous_rest.png
+        rotateright_hover.png zoomin_rest.png
+      ]
+    end
+
+    initializer 'openseadragon.importmap', before: 'importmap' do |app|
+      app.config.assets.paths << Engine.root.join('app/javascript')
+      app.config.importmap.paths << Engine.root.join('config/importmap.rb') if app.config.respond_to?(:importmap)
     end
   end
 end


### PR DESCRIPTION
Can we add these assets to precompile in the engine like this or is this a responsibility of the host app? This fixes half of my Spotlight v4 issue with current versions of OSD.