### PR TITLE
Add default style in install generator

### DIFF
--- a/lib/generators/openseadragon/install_generator.rb
+++ b/lib/generators/openseadragon/install_generator.rb
@@ -27,6 +27,15 @@ module Openseadragon
       end
     end
 
+    def add_default_style
+      copy_file 'openseadragon.css', 'app/assets/stylesheets/openseadragon.css'
+  
+      if (scss_file = %w[app/assets/stylesheets/application.bootstrap.scss
+                         app/assets/stylesheets/application.scss].find { |f| File.exist?(f) })
+        append_to_file scss_file, "\n@import 'openseadragon';\n"
+      end
+    end
+
     def inject_helper
       inject_into_class 'app/controllers/application_controller.rb', ApplicationController do
         "  helper Openseadragon::OpenseadragonHelper\n"

--- a/lib/generators/openseadragon/templates/openseadragon.css
+++ b/lib/generators/openseadragon/templates/openseadragon.css
@@ -1,3 +1,3 @@
-/*
- *= require openseadragon/openseadragon
- */
+.openseadragon-viewer {
+  min-height: 500px;
+}


### PR DESCRIPTION
We had something like this for the sprockets build, so that the OSD viewer would be visible by default if the app didn't specify dimensions.

Spotlight needs something like this for the test app. If we don't want to do this here anymore, we can add the one liner to the Spotlight test app generator.